### PR TITLE
Patch pal2 x11 cleanup

### DIFF
--- a/src/OpenTK.Platform.Native/DllResolver.cs
+++ b/src/OpenTK.Platform.Native/DllResolver.cs
@@ -22,17 +22,6 @@ namespace OpenTK.Platform.Native
 
         public static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
         {
-            // if (OperatingSystem.IsLinux() && libraryName == "GL")
-            // {
-            //     // On linux we want to try libGL.so and libGL.so.1
-            //     IntPtr lib;
-            //     if (NativeLibrary.TryLoad("libGL.so", assembly, searchPath, out lib))
-            //         return lib;
-
-            //     if (NativeLibrary.TryLoad("libGL.so.1", assembly, searchPath, out lib))
-            //         return lib;
-            // }
-
             if (OperatingSystem.IsLinux() && LinuxLibraryList.TryGetValue(libraryName, out IReadOnlyCollection<string>? names))
             {
                 foreach(string name in names)

--- a/src/OpenTK.Platform.Native/DllResolver.cs
+++ b/src/OpenTK.Platform.Native/DllResolver.cs
@@ -22,18 +22,64 @@ namespace OpenTK.Platform.Native
 
         public static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
         {
-            if (OperatingSystem.IsLinux() && libraryName == "GL")
-            {
-                // On linux we want to try libGL.so and libGL.so.1
-                IntPtr lib;
-                if (NativeLibrary.TryLoad("libGL.so", assembly, searchPath, out lib))
-                    return lib;
+            // if (OperatingSystem.IsLinux() && libraryName == "GL")
+            // {
+            //     // On linux we want to try libGL.so and libGL.so.1
+            //     IntPtr lib;
+            //     if (NativeLibrary.TryLoad("libGL.so", assembly, searchPath, out lib))
+            //         return lib;
 
-                if (NativeLibrary.TryLoad("libGL.so.1", assembly, searchPath, out lib))
-                    return lib;
+            //     if (NativeLibrary.TryLoad("libGL.so.1", assembly, searchPath, out lib))
+            //         return lib;
+            // }
+
+            if (OperatingSystem.IsLinux() && LinuxLibraryList.TryGetValue(libraryName, out IReadOnlyCollection<string>? names))
+            {
+                foreach(string name in names)
+                {
+                    if (NativeLibrary.TryLoad(name, assembly, searchPath, out IntPtr lib))
+                        return lib;
+                }
             }
 
             return IntPtr.Zero;
         }
+
+        /// <summary>
+        /// A dictionary of a priority list of library search names for the
+        /// Linux family of operating systems.
+        /// </summary>
+        private static readonly IReadOnlyDictionary<string, IReadOnlyCollection<string>> LinuxLibraryList =
+        new Dictionary<string, IReadOnlyCollection<string>>
+        {
+            ["GL"] = new string[]
+            {
+                "libGL.so",
+                "libGL.so.1",
+                "libGL.so.0"
+            },
+
+            // FIXME: By default let the OS decide, if that fails use vendor. Add other vendor GLX versions.
+            ["GLX"] = new string[]
+            {
+                "libGLX.so",
+                "libGLX.so.0",
+                "libGLX_nvidia.so.1",
+                "libGLX_nvidia.so.0",
+                "libGLX_mesa.so.0"
+            },
+
+            ["X11"] = new string[]
+            {
+                "libX11.so",
+                "libX11.so.6",
+                "libX11.so.5",
+                "libX11.so.4",
+                "libX11.so.3",
+                "libX11.so.2",
+                "libX11.so.1",
+                "libX11.so.0"
+            }
+        };
     }
 }

--- a/src/OpenTK.Platform.Native/X11/X11DisplayComponent.cs
+++ b/src/OpenTK.Platform.Native/X11/X11DisplayComponent.cs
@@ -42,11 +42,9 @@ namespace OpenTK.Platform.Native.X11
                 DisplayExtension = DisplayExtensionType.None;
             }
 
-            Debug.WriteLine($"Using display extension: {DisplayExtension}.", "PAL2.0/Linux/X11/Display");
-            Debug.WriteLineIf(
-                DisplayExtension != DisplayExtensionType.None,
-                $"{DisplayExtension} version {DisplayExtensionVersion}",
-                "PAL2.0/Linux/X11/Display");
+            Logger?.LogInfo($"Using display extension: {DisplayExtension}.");
+            if (DisplayExtension != DisplayExtensionType.None)
+                Logger?.LogInfo($"{DisplayExtension} version {DisplayExtensionVersion}");
         }
 
         // TODO: Write Xinerama fallback.

--- a/src/OpenTK.Platform.Native/X11/X11OpenGLComponent.cs
+++ b/src/OpenTK.Platform.Native/X11/X11OpenGLComponent.cs
@@ -82,7 +82,7 @@ namespace OpenTK.Platform.Native.X11
                 throw new PalException(this, "GLX_ARB_create_context is required (for the time being).");
             }
 
-            Debug.WriteLine(
+            Logger?.LogInfo(
                 $"GLX Version {major}.{minor}\n" +
                 $"  Extensions ({GLXExtensions.Count}) {extensions}\n" +
                  "  Client:\n" +
@@ -92,8 +92,7 @@ namespace OpenTK.Platform.Native.X11
                  "  Server:\n" +
                 $"    Versions: {GLXServerVersion?.ToString() ?? "???"}\n" +
                 $"    Vendor: {GLXServerVendor}\n" +
-                $"    Extensions: ({GLXServerExtensions.Count}) {serverExtensions}",
-                "PAL-2.0/Linux/X11/OpenGL"
+                $"    Extensions: ({GLXServerExtensions.Count}) {serverExtensions}"
             );
         }
 


### PR DESCRIPTION
* Made DLLResolver.cs cleaner by using a priority list defined at the bottom of the file.
* Removed remnants of the Debugger.Write* to use the ILogger interface.